### PR TITLE
Child key derivation, aka HD support, based on BIP-32

### DIFF
--- a/cmd/tss-benchsign/main.go
+++ b/cmd/tss-benchsign/main.go
@@ -132,7 +132,7 @@ func runSign(dir string, t int) {
 	// init the parties
 	for i := 0; i < len(signPIDs); i++ {
 		params := tss.NewParameters(p2pCtx, signPIDs[i], len(signPIDs), t)
-		P := signing.NewLocalParty(msg, params, keys[i], outCh, endCh).(*signing.LocalParty)
+		P := signing.NewLocalParty(msg, params, keys[i], big.NewInt(0), outCh, endCh).(*signing.LocalParty)
 		parties = append(parties, P)
 		go func(P *signing.LocalParty) {
 			if err := P.Start(); err != nil {

--- a/crypto/ckd/child_key_derivation.go
+++ b/crypto/ckd/child_key_derivation.go
@@ -1,0 +1,132 @@
+// Copyright © Swingby
+
+package ckd
+
+import (
+	"crypto/ecdsa"
+	"crypto/hmac"
+	"crypto/sha512"
+	"encoding/binary"
+	"errors"
+	"math/big"
+
+	"github.com/binance-chain/tss-lib/common"
+	"github.com/binance-chain/tss-lib/crypto"
+	"github.com/binance-chain/tss-lib/tss"
+)
+
+type ExtendedKey struct {
+	ecdsa.PublicKey
+	Depth      byte
+	ChildIndex uint32
+	ChainCode  []byte // 32 bytes
+}
+
+// For more information about child key derivation see https://github.com/binance-chain/tss-lib/issues/104
+// https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki .
+// The functions below do not implement the full BIP-32 specification. As mentioned in the Jira ticket above,
+// we only use non-hardened derived keys.
+
+const (
+
+	// HardenedKeyStart hardened key starts.
+	HardenedKeyStart = 0x80000000 // 2^31
+
+	// max Depth
+	maxDepth = 0xFF
+
+	PubKeyBytesLenCompressed = 33
+
+	pubKeyCompressed byte = 0x2
+)
+
+func isOdd(a *big.Int) bool {
+	return a.Bit(0) == 1
+}
+
+// PaddedAppend append src to dst, if less than size padding 0 at start
+func PaddedAppend(dst []byte, srcPaddedSize int, src []byte) []byte {
+	return append(dst, PaddedBytes(srcPaddedSize, src)...)
+}
+
+// PaddedBytes padding byte array to size length
+func PaddedBytes(size int, src []byte) []byte {
+	offset := size - len(src)
+	tmp := src
+	if offset > 0 {
+		tmp = make([]byte, size)
+		copy(tmp[offset:], src)
+	}
+	return tmp
+}
+
+// SerializeCompressed serializes a public key 33-byte compressed format
+func SerializeCompressed(publicKeyX *big.Int, publicKeyY *big.Int) []byte {
+	b := make([]byte, 0, PubKeyBytesLenCompressed)
+	format := pubKeyCompressed
+	if isOdd(publicKeyY) {
+		format |= 0x1
+	}
+	b = append(b, format)
+	return PaddedAppend(b, 32, publicKeyX.Bytes())
+}
+
+func DeriveChildKeyFromHierarchy(indicesHierarchy []uint32, pk *ExtendedKey, mod *big.Int) (*big.Int, *ExtendedKey, error) {
+	var k = pk
+	var err error
+	var childKey *ExtendedKey
+	mod_ := common.ModInt(mod)
+	ilNum := big.NewInt(0)
+	for index := range indicesHierarchy {
+		ilNumOld := ilNum
+		ilNum, childKey, err = DeriveChildKey(indicesHierarchy[index], k)
+		if err != nil {
+			return nil, nil, err
+		}
+		k = childKey
+		ilNum = mod_.Add(ilNum, ilNumOld)
+	}
+	return ilNum, k, nil
+}
+
+// Derive a child key from the given parent key. The function returns "IL" ("I left"), per BIP-32 spec. It also
+// returns the derived child key.
+func DeriveChildKey(index uint32, pk *ExtendedKey) (*big.Int, *ExtendedKey, error) {
+	if index >= HardenedKeyStart {
+		return nil, nil, errors.New("the index must be non-hardened")
+	}
+	if pk.Depth == maxDepth {
+		return nil, nil, errors.New("cannot derive key beyond max depth")
+	}
+
+	cryptoPk, err := crypto.NewECPoint(tss.EC(), pk.X, pk.Y)
+
+	data := make([]byte, 37)
+	copy(data, SerializeCompressed(pk.X, pk.Y))
+	binary.BigEndian.PutUint32(data[33:], index)
+
+	// I = HMAC-SHA512(Key = chainCode, Data=data)
+	hmac512 := hmac.New(sha512.New, pk.ChainCode)
+	hmac512.Write(data)
+	ilr := hmac512.Sum(nil)
+	il := ilr[:32]
+	childChainCode := ilr[32:]
+	ilNum := new(big.Int).SetBytes(il)
+	deltaG := crypto.ScalarBaseMult(tss.EC(), ilNum)
+	if err != nil {
+		common.Logger.Error("error computing delta G")
+		return nil, nil, err
+	}
+	childCryptoPk, err := cryptoPk.Add(deltaG)
+	if err != nil {
+		common.Logger.Error("error adding delta G to parent key")
+		return nil, nil, err
+	}
+	childPk := &ExtendedKey{
+		PublicKey:  *childCryptoPk.ToECDSAPubKey(),
+		Depth:      pk.Depth + 1,
+		ChildIndex: index,
+		ChainCode:  childChainCode,
+	}
+	return ilNum, childPk, nil
+}

--- a/ecdsa/resharing/local_party_test.go
+++ b/ecdsa/resharing/local_party_test.go
@@ -172,7 +172,7 @@ signing:
 
 	for j, signPID := range signPIDs {
 		params := tss.NewParameters(signP2pCtx, signPID, len(signPIDs), newThreshold)
-		P := signing.NewLocalParty(big.NewInt(42), params, signKeys[j], signOutCh, signEndCh).(*signing.LocalParty)
+		P := signing.NewLocalParty(big.NewInt(42), params, signKeys[j], big.NewInt(0), signOutCh, signEndCh).(*signing.LocalParty)
 		signParties = append(signParties, P)
 		go func(P *signing.LocalParty) {
 			if err := P.Start(); err != nil {

--- a/ecdsa/signing/key_derivation_test.go
+++ b/ecdsa/signing/key_derivation_test.go
@@ -1,0 +1,150 @@
+// Copyright © 2019 Binance
+//
+// This file is part of Binance. The full Binance copyright notice, including
+// terms governing use, modification, and redistribution, is contained in the
+// file LICENSE at the root of the source code distribution tree.
+
+package signing
+
+import (
+	"crypto/ecdsa"
+	"fmt"
+	"math/big"
+	"runtime"
+	"sync/atomic"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/binance-chain/tss-lib/common"
+	"github.com/binance-chain/tss-lib/crypto"
+	"github.com/binance-chain/tss-lib/crypto/ckd"
+	"github.com/binance-chain/tss-lib/ecdsa/keygen"
+	"github.com/binance-chain/tss-lib/test"
+	"github.com/binance-chain/tss-lib/tss"
+)
+
+// For more information about child key derivation see https://github.com/binance-chain/tss-lib/issues/104
+// https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki .
+// As mentioned in the Jira ticket above, we only use non-hardened derived keys.
+// Differently from the Jira ticket, our code only updates xi and bigXj
+// in signing. Our code does not require updates u_i or the VSS commitment to the polynomial either,
+// as these are not used during the signing phase.
+func TestHDKeyDerivation(t *testing.T) {
+	setUp("debug")
+	threshold := testThreshold
+
+	// PHASE: load keygen fixtures
+	keys, signPIDs, err := keygen.LoadKeygenTestFixturesRandomSet(testThreshold+1, testParticipants)
+	assert.NoError(t, err, "should load keygen fixtures")
+	assert.Equal(t, testThreshold+1, len(keys))
+	assert.Equal(t, testThreshold+1, len(signPIDs))
+
+	// build ecdsa key pair
+	parentPkX, parentPkY := keys[0].ECDSAPub.X(), keys[0].ECDSAPub.Y()
+	pk := ecdsa.PublicKey{
+		Curve: tss.EC(),
+		X:     parentPkX,
+		Y:     parentPkY,
+	}
+
+	// setting the chain code to a random positive number smaller than the maximum allowed of 32 bytes
+	chainCode := make([]byte, 32)
+	max32b := new(big.Int).Lsh(new(big.Int).SetUint64(1), 256)
+	max32b = new(big.Int).Sub(max32b, new(big.Int).SetUint64(1))
+	common.GetRandomPositiveInt(max32b).FillBytes(chainCode)
+
+	extendedParentPk := &ckd.ExtendedKey{
+		PublicKey:  pk,
+		Depth:      0,
+		ChildIndex: 0,
+		ChainCode:  chainCode,
+	}
+
+	// Using an arbitrary path of indices. In the common notation, this would be "m/13/209/3".
+	il, extendedChildPk, errorDerivation := ckd.DeriveChildKeyFromHierarchy([]uint32{13, 209, 3}, extendedParentPk,
+		tss.EC().Params().N)
+	assert.NoErrorf(t, errorDerivation, "there should not be an error deriving the child public key")
+
+	keyDerivationDelta := il
+
+	err = UpdatePublicKeyAndAdjustBigXj(keyDerivationDelta, keys, &extendedChildPk.PublicKey)
+	assert.NoErrorf(t, err, "there should not be an error setting the derived keys")
+
+	// PHASE: signing
+	// use a shuffled selection of the list of parties for this test
+	p2pCtx := tss.NewPeerContext(signPIDs)
+	parties := make([]*LocalParty, 0, len(signPIDs))
+
+	errCh := make(chan *tss.Error, len(signPIDs))
+	outCh := make(chan tss.Message, len(signPIDs))
+	endCh := make(chan *SignatureData, len(signPIDs))
+
+	updater := test.SharedPartyUpdater
+
+	msg, parties, errCh := initTheParties(signPIDs, p2pCtx, threshold, keys, keyDerivationDelta, outCh, endCh, parties, errCh)
+
+	var ended int32
+signing:
+	for {
+		fmt.Printf("ACTIVE GOROUTINES: %d\n", runtime.NumGoroutine())
+		select {
+		case err := <-errCh:
+			common.Logger.Errorf("Error: %s", err)
+			assert.FailNow(t, err.Error())
+			break signing
+
+		case msg := <-outCh:
+			dest := msg.GetTo()
+			if dest == nil {
+				for _, P := range parties {
+					if P.PartyID().Index == msg.GetFrom().Index {
+						continue
+					}
+					go updater(P, msg, errCh)
+				}
+			} else {
+				if dest[0].Index == msg.GetFrom().Index {
+					t.Fatalf("party %d tried to send a message to itself (%d)", dest[0].Index, msg.GetFrom().Index)
+				}
+				go updater(parties[dest[0].Index], msg, errCh)
+			}
+
+		case data := <-endCh:
+			atomic.AddInt32(&ended, 1)
+			if atomic.LoadInt32(&ended) == int32(len(signPIDs)) {
+				t.Logf("Done. Received signature data from %d participants %+v", ended, data)
+
+				// bigR is stored as bytes for the OneRoundData protobuf struct
+				bigRX, bigRY := new(big.Int).SetBytes(parties[0].temp.BigR.GetX()), new(big.Int).SetBytes(parties[0].temp.BigR.GetY())
+				bigR := crypto.NewECPointNoCurveCheck(tss.EC(), bigRX, bigRY)
+
+				r := parties[0].temp.rI.X()
+				fmt.Printf("sign result: R(%s, %s), r=%s\n", bigR.X().String(), bigR.Y().String(), r.String())
+
+				modN := common.ModInt(tss.EC().Params().N)
+
+				// BEGIN check s correctness
+				sumS := big.NewInt(0)
+				for _, p := range parties {
+					sumS = modN.Add(sumS, p.temp.sI)
+				}
+				fmt.Printf("S: %s\n", sumS.String())
+				// END check s correctness
+
+				ok := ecdsa.Verify(&extendedChildPk.PublicKey, msg.Bytes(), bigR.X(), sumS)
+				assert.True(t, ok, "ecdsa verify must pass")
+
+				btcecSig := &btcec.Signature{R: r, S: sumS}
+				btcecSig.Verify(msg.Bytes(), (*btcec.PublicKey)(&extendedChildPk.PublicKey))
+				assert.True(t, ok, "ecdsa verify 2 must pass")
+
+				t.Log("ECDSA signing test done.")
+				// END ECDSA verify
+
+				break signing
+			}
+		}
+	}
+}

--- a/ecdsa/signing/key_derivation_test.go
+++ b/ecdsa/signing/key_derivation_test.go
@@ -1,8 +1,4 @@
-// Copyright © 2019 Binance
-//
-// This file is part of Binance. The full Binance copyright notice, including
-// terms governing use, modification, and redistribution, is contained in the
-// file LICENSE at the root of the source code distribution tree.
+// Copyright © 2021 Swingby
 
 package signing
 

--- a/ecdsa/signing/key_derivation_util.go
+++ b/ecdsa/signing/key_derivation_util.go
@@ -1,0 +1,35 @@
+// Copyright © 2021 Swingby
+
+package signing
+
+import (
+	"crypto/ecdsa"
+	"math/big"
+
+	"github.com/binance-chain/tss-lib/common"
+	"github.com/binance-chain/tss-lib/crypto"
+	"github.com/binance-chain/tss-lib/ecdsa/keygen"
+	"github.com/binance-chain/tss-lib/tss"
+)
+
+func UpdatePublicKeyAndAdjustBigXj(keyDerivationDelta *big.Int, keys []keygen.LocalPartySaveData,
+	extendedChildPk *ecdsa.PublicKey) error {
+	var err error
+	gDelta := crypto.ScalarBaseMult(tss.EC(), keyDerivationDelta)
+	for k := range keys {
+		keys[k].ECDSAPub, err = crypto.NewECPoint(tss.EC(), extendedChildPk.X, extendedChildPk.Y)
+		if err != nil {
+			common.Logger.Errorf("error creating new extended child public key")
+			return err
+		}
+
+		for j := range keys[k].BigXj {
+			keys[k].BigXj[j], err = keys[k].BigXj[j].Add(gDelta)
+			if err != nil {
+				common.Logger.Errorf("error in delta operation")
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/ecdsa/signing/local_party.go
+++ b/ecdsa/signing/local_party.go
@@ -59,6 +59,7 @@ type (
 		rAKI,
 		deltaI,
 		sigmaI,
+		keyDerivationDelta,
 		gammaI *big.Int
 		c1Is     []*big.Int
 		bigWs    []*crypto.ECPoint
@@ -96,6 +97,7 @@ func NewLocalParty(
 	msg *big.Int,
 	params *tss.Parameters,
 	key keygen.LocalPartySaveData,
+	keyDerivationDelta *big.Int,
 	out chan<- tss.Message,
 	end chan<- *SignatureData,
 ) tss.Party {
@@ -119,6 +121,7 @@ func NewLocalParty(
 	p.temp.signRound6Messages = make([]tss.ParsedMessage, partyCount)
 	p.temp.signRound7Messages = make([]tss.ParsedMessage, partyCount)
 	// temp data init
+	p.temp.keyDerivationDelta = keyDerivationDelta
 	p.temp.m = msg
 	p.temp.c1Is = make([]*big.Int, partyCount)
 	p.temp.bigWs = make([]*crypto.ECPoint, partyCount)
@@ -138,10 +141,11 @@ func NewLocalParty(
 func NewLocalPartyWithOneRoundSign(
 	params *tss.Parameters,
 	key keygen.LocalPartySaveData,
+	keyDerivationDelta *big.Int,
 	out chan<- tss.Message,
 	end chan<- *SignatureData,
 ) tss.Party {
-	return NewLocalParty(nil, params, key, out, end)
+	return NewLocalParty(nil, params, key, keyDerivationDelta, out, end)
 }
 
 func (p *LocalParty) FirstRound() tss.Round {

--- a/ecdsa/signing/local_party_test.go
+++ b/ecdsa/signing/local_party_test.go
@@ -38,13 +38,16 @@ func setUp(level string) {
 	}
 }
 
-func initTheParties(signPIDs tss.SortedPartyIDs, p2pCtx *tss.PeerContext, threshold int, keys []keygen.LocalPartySaveData, outCh chan tss.Message, endCh chan *SignatureData, parties []*LocalParty, errCh chan *tss.Error) (*big.Int, []*LocalParty, chan *tss.Error) {
+func initTheParties(signPIDs tss.SortedPartyIDs, p2pCtx *tss.PeerContext, threshold int,
+	keys []keygen.LocalPartySaveData, keyDerivationDelta *big.Int, outCh chan tss.Message,
+	endCh chan *SignatureData, parties []*LocalParty,
+	errCh chan *tss.Error) (*big.Int, []*LocalParty, chan *tss.Error) {
 	// init the parties
 	msg := common.GetRandomPrimeInt(256)
 	for i := 0; i < len(signPIDs); i++ {
 		params := tss.NewParameters(p2pCtx, signPIDs[i], len(signPIDs), threshold)
 
-		P := NewLocalParty(msg, params, keys[i], outCh, endCh).(*LocalParty)
+		P := NewLocalParty(msg, params, keys[i], keyDerivationDelta, outCh, endCh).(*LocalParty)
 		parties = append(parties, P)
 		go func(P *LocalParty) {
 			if err := P.Start(); err != nil {
@@ -76,7 +79,7 @@ func TestE2EConcurrent(t *testing.T) {
 
 	updater := test.SharedPartyUpdater
 
-	msg, parties, errCh := initTheParties(signPIDs, p2pCtx, threshold, keys, outCh, endCh, parties, errCh)
+	msg, parties, errCh := initTheParties(signPIDs, p2pCtx, threshold, keys, big.NewInt(0), outCh, endCh, parties, errCh)
 
 	var ended int32
 signing:
@@ -248,7 +251,7 @@ func TestType7Abort(t *testing.T) {
 
 	updater := type7IdentifiedAbortUpdater
 
-	_, parties, errCh = initTheParties(signPIDs, p2pCtx, threshold, keys, outCh, endCh, parties, errCh)
+	_, parties, errCh = initTheParties(signPIDs, p2pCtx, threshold, keys, big.NewInt(0), outCh, endCh, parties, errCh)
 
 signing:
 	for {
@@ -368,7 +371,7 @@ func TestType4IdentifiedAbort(t *testing.T) {
 
 	updater := type4IdentifiedAbortUpdater
 
-	_, parties, errCh = initTheParties(signPIDs, p2pCtx, threshold, keys, outCh, endCh, parties, errCh)
+	_, parties, errCh = initTheParties(signPIDs, p2pCtx, threshold, keys, big.NewInt(0), outCh, endCh, parties, errCh)
 
 signing:
 	for {
@@ -516,7 +519,7 @@ func TestType5IdentifiedAbort(t *testing.T) {
 
 	updater := type5IdentifiedAbortUpdater
 
-	_, parties, errCh = initTheParties(signPIDs, p2pCtx, threshold, keys, outCh, endCh, parties, errCh)
+	_, parties, errCh = initTheParties(signPIDs, p2pCtx, threshold, keys, big.NewInt(0), outCh, endCh, parties, errCh)
 
 signing:
 	for {

--- a/ecdsa/signing/round_1.go
+++ b/ecdsa/signing/round_1.go
@@ -138,6 +138,12 @@ func (round *round1) NextRound() tss.Round {
 func (round *round1) prepare() error {
 	i := round.PartyID().Index
 	xi, ks, bigXs := round.key.Xi, round.key.Ks, round.key.BigXj
+
+	// adding the key derivation delta to the xi's
+	mod := common.ModInt(tss.EC().Params().N)
+	xi = mod.Add(round.temp.keyDerivationDelta, xi)
+	round.key.Xi = xi
+
 	if round.Threshold()+1 > len(ks) {
 		return fmt.Errorf("t+1=%d is not satisfied by the key count of %d", round.Threshold()+1, len(ks))
 	}


### PR DESCRIPTION
Implementing child key derivation, aka HD support, based on BIP-32. We only use non-hardened derived keys. We update xi's and bigXj in signing. Differently from other implementations, this change does not require updates u_i or the VSS commitment to the polynomial either, as these are not used during the signing phase. This change does not need a leader party either.