### PR TITLE
verifying that the threshold is less than n

### DIFF
--- a/ecdsa/keygen/local_party_test.go
+++ b/ecdsa/keygen/local_party_test.go
@@ -44,10 +44,75 @@ func setUp(level string) {
 	}
 }
 
-func TestStartRound1Paillier(t *testing.T) {
-	setUp("debug")
+func handleMessage(t *testing.T, msg tss.Message, parties []*LocalParty, updater func(party tss.Party, msg tss.Message, errCh chan<- *tss.Error), errCh chan *tss.Error) bool {
+	dest := msg.GetTo()
+	if dest == nil { // broadcast!
+		for _, P := range parties {
+			if P.PartyID().Index == msg.GetFrom().Index {
+				continue
+			}
+			go updater(P, msg, errCh)
+		}
+	} else { // point-to-point!
+		if dest[0].Index == msg.GetFrom().Index {
+			t.Fatalf("party %d tried to send a message to itself (%d)", dest[0].Index, msg.GetFrom().Index)
+			return true
+		}
+		go updater(parties[dest[0].Index], msg, errCh)
+	}
+	return false
+}
 
-	pIDs := tss.GenerateTestPartyIDs(1)
+func initTheParties(pIDs tss.SortedPartyIDs, p2pCtx *tss.PeerContext, threshold int, fixtures []LocalPartySaveData, outCh chan tss.Message, endCh chan LocalPartySaveData, parties []*LocalParty, errCh chan *tss.Error) ([]*LocalParty, chan *tss.Error) {
+	// init the parties
+	for i := 0; i < len(pIDs); i++ {
+		var P *LocalParty
+		params := tss.NewParameters(p2pCtx, pIDs[i], len(pIDs), threshold)
+		if i < len(fixtures) {
+			P = NewLocalParty(params, outCh, endCh, fixtures[i].LocalPreParams).(*LocalParty)
+		} else {
+			P = NewLocalParty(params, outCh, endCh).(*LocalParty)
+		}
+		parties = append(parties, P)
+		go func(P *LocalParty) {
+			if err := P.Start(); err != nil {
+				errCh <- err
+			}
+		}(P)
+	}
+	return parties, errCh
+}
+
+func tryWriteTestFixtureFile(t *testing.T, index int, data LocalPartySaveData) {
+	fixtureFileName := makeTestFixtureFilePath(index)
+
+	// fixture file does not already exist?
+	// if it does, we won't re-create it here
+	fi, err := os.Stat(fixtureFileName)
+	if !(err == nil && fi != nil && !fi.IsDir()) {
+		fd, err := os.OpenFile(fixtureFileName, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+		if err != nil {
+			assert.NoErrorf(t, err, "unable to open fixture file %s for writing", fixtureFileName)
+		}
+		bz, err := json.Marshal(&data)
+		if err != nil {
+			t.Fatalf("unable to marshal save data for fixture file %s", fixtureFileName)
+		}
+		_, err = fd.Write(bz)
+		if err != nil {
+			t.Fatalf("unable to write to fixture file %s", fixtureFileName)
+		}
+		t.Logf("Saved a test fixture file for party %d: %s", index, fixtureFileName)
+	} else {
+		t.Logf("Fixture file already exists for party %d; not re-creating: %s", index, fixtureFileName)
+	}
+	//
+}
+
+func TestStartRound1Paillier(t *testing.T) {
+	setUp("info")
+
+	pIDs := tss.GenerateTestPartyIDs(2)
 	p2pCtx := tss.NewPeerContext(pIDs)
 	threshold := 1
 	params := tss.NewParameters(p2pCtx, pIDs[0], len(pIDs), threshold)
@@ -85,9 +150,9 @@ func TestStartRound1Paillier(t *testing.T) {
 }
 
 func TestFinishAndSaveH1H2(t *testing.T) {
-	setUp("debug")
+	setUp("info")
 
-	pIDs := tss.GenerateTestPartyIDs(1)
+	pIDs := tss.GenerateTestPartyIDs(2)
 	p2pCtx := tss.NewPeerContext(pIDs)
 	threshold := 1
 	params := tss.NewParameters(p2pCtx, pIDs[0], len(pIDs), threshold)
@@ -133,7 +198,7 @@ func TestFinishAndSaveH1H2(t *testing.T) {
 }
 
 func TestBadMessageCulprits(t *testing.T) {
-	setUp("debug")
+	setUp("info")
 
 	pIDs := tss.GenerateTestPartyIDs(2)
 	p2pCtx := tss.NewPeerContext(pIDs)
@@ -602,69 +667,4 @@ keygen:
 			}
 		}
 	}
-}
-
-func handleMessage(t *testing.T, msg tss.Message, parties []*LocalParty, updater func(party tss.Party, msg tss.Message, errCh chan<- *tss.Error), errCh chan *tss.Error) bool {
-	dest := msg.GetTo()
-	if dest == nil { // broadcast!
-		for _, P := range parties {
-			if P.PartyID().Index == msg.GetFrom().Index {
-				continue
-			}
-			go updater(P, msg, errCh)
-		}
-	} else { // point-to-point!
-		if dest[0].Index == msg.GetFrom().Index {
-			t.Fatalf("party %d tried to send a message to itself (%d)", dest[0].Index, msg.GetFrom().Index)
-			return true
-		}
-		go updater(parties[dest[0].Index], msg, errCh)
-	}
-	return false
-}
-
-func initTheParties(pIDs tss.SortedPartyIDs, p2pCtx *tss.PeerContext, threshold int, fixtures []LocalPartySaveData, outCh chan tss.Message, endCh chan LocalPartySaveData, parties []*LocalParty, errCh chan *tss.Error) ([]*LocalParty, chan *tss.Error) {
-	// init the parties
-	for i := 0; i < len(pIDs); i++ {
-		var P *LocalParty
-		params := tss.NewParameters(p2pCtx, pIDs[i], len(pIDs), threshold)
-		if i < len(fixtures) {
-			P = NewLocalParty(params, outCh, endCh, fixtures[i].LocalPreParams).(*LocalParty)
-		} else {
-			P = NewLocalParty(params, outCh, endCh).(*LocalParty)
-		}
-		parties = append(parties, P)
-		go func(P *LocalParty) {
-			if err := P.Start(); err != nil {
-				errCh <- err
-			}
-		}(P)
-	}
-	return parties, errCh
-}
-
-func tryWriteTestFixtureFile(t *testing.T, index int, data LocalPartySaveData) {
-	fixtureFileName := makeTestFixtureFilePath(index)
-
-	// fixture file does not already exist?
-	// if it does, we won't re-create it here
-	fi, err := os.Stat(fixtureFileName)
-	if !(err == nil && fi != nil && !fi.IsDir()) {
-		fd, err := os.OpenFile(fixtureFileName, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
-		if err != nil {
-			assert.NoErrorf(t, err, "unable to open fixture file %s for writing", fixtureFileName)
-		}
-		bz, err := json.Marshal(&data)
-		if err != nil {
-			t.Fatalf("unable to marshal save data for fixture file %s", fixtureFileName)
-		}
-		_, err = fd.Write(bz)
-		if err != nil {
-			t.Fatalf("unable to write to fixture file %s", fixtureFileName)
-		}
-		t.Logf("Saved a test fixture file for party %d: %s", index, fixtureFileName)
-	} else {
-		t.Logf("Fixture file already exists for party %d; not re-creating: %s", index, fixtureFileName)
-	}
-	//
 }

--- a/ecdsa/keygen/round_1.go
+++ b/ecdsa/keygen/round_1.go
@@ -32,6 +32,9 @@ func newRound1(params *tss.Parameters, save *LocalPartySaveData, temp *localTemp
 }
 
 func (round *round1) Start() *tss.Error {
+	if err := round.ValidateParams(); err != nil {
+		return round.WrapError(*err)
+	}
 	if round.started {
 		return round.WrapError(errors.New("round already started"))
 	}

--- a/ecdsa/keygen/rounds.go
+++ b/ecdsa/keygen/rounds.go
@@ -7,6 +7,8 @@
 package keygen
 
 import (
+	"errors"
+
 	"github.com/binance-chain/tss-lib/ecdsa"
 	"github.com/binance-chain/tss-lib/tss"
 )
@@ -51,6 +53,14 @@ var (
 
 func (round *base) Params() *tss.Parameters {
 	return round.Parameters
+}
+
+func (round *base) ValidateParams() *error {
+    if round.Threshold()>=round.PartyCount() {
+    	err := errors.New("t<n necessarily with the dishonest majority assumption")
+    	return &err
+    }
+	return nil
 }
 
 func (round *base) RoundNumber() int {

--- a/ecdsa/keygen/rounds.go
+++ b/ecdsa/keygen/rounds.go
@@ -56,10 +56,10 @@ func (round *base) Params() *tss.Parameters {
 }
 
 func (round *base) ValidateParams() *error {
-    if round.Threshold()>=round.PartyCount() {
-    	err := errors.New("t<n necessarily with the dishonest majority assumption")
-    	return &err
-    }
+	if round.Threshold() >= round.PartyCount() {
+		err := errors.New("t<n necessarily with the dishonest majority assumption")
+		return &err
+	}
 	return nil
 }
 

--- a/tss/params.go
+++ b/tss/params.go
@@ -43,9 +43,12 @@ const (
 // Exported, used in `tss` client
 func NewParameters(ctx *PeerContext, partyID *PartyID, partyCount, threshold int, optionalSafePrimeGenTimeout ...time.Duration) *Parameters {
 	var safePrimeGenTimeout time.Duration
+	if threshold >= partyCount {
+		panic(errors.New("NewParameters: t<n necessarily with the dishonest majority assumption"))
+	}
 	if 0 < len(optionalSafePrimeGenTimeout) {
 		if 1 < len(optionalSafePrimeGenTimeout) {
-			panic(errors.New("GeneratePreParams: expected 0 or 1 item in `optionalSafePrimeGenTimeout`"))
+			panic(errors.New("NewParameters: expected 0 or 1 item in `optionalSafePrimeGenTimeout`"))
 		}
 		safePrimeGenTimeout = optionalSafePrimeGenTimeout[0]
 	} else {


### PR DESCRIPTION
Security - verifying that the threshold is less than n, the number of shares, in round 1. Moving private functions in local_party_test.go without change to functionality. 
This pull request is based on one point from an audit feedback for GG20 from Bi__ce:
"* missing check of (t,n) correctness, e.g. protocol starting and crashing with t=n, instead of explicit check"