### PR TITLE
R4R Adding a field to hold the most recent reshare epoch

### DIFF
--- a/ecdsa/keygen/save_data.go
+++ b/ecdsa/keygen/save_data.go
@@ -53,6 +53,8 @@ type (
 
 		// The ReshareKeyOffset is 0 before a reshare run and is set to an epoch each reshare run.
 		ReshareKeyOffset uint64
+
+		MostRecentReshareEpoch int64
 	}
 )
 


### PR DESCRIPTION
A minor change to support reshare. Adding a field to hold the most recent reshare epoch.