### PR TITLE
hotfix - modular Feldman VSS, modular User ID comparison

### DIFF
--- a/crypto/vss/feldman_vss_test.go
+++ b/crypto/vss/feldman_vss_test.go
@@ -17,6 +17,32 @@ import (
 	"github.com/binance-chain/tss-lib/tss"
 )
 
+func TestCheckIndexesDup(t *testing.T) {
+	indexes := make([]*big.Int, 0)
+	for i := 0; i < 1000; i++ {
+		indexes = append(indexes, common.GetRandomPositiveInt(tss.EC().Params().N))
+	}
+	_, e := CheckIndexes(tss.EC(), indexes)
+	assert.NoError(t, e)
+
+	indexes = append(indexes, indexes[99])
+	_, e = CheckIndexes(tss.EC(), indexes)
+	assert.Error(t, e)
+}
+
+func TestCheckIndexesZero(t *testing.T) {
+	indexes := make([]*big.Int, 0)
+	for i := 0; i < 1000; i++ {
+		indexes = append(indexes, common.GetRandomPositiveInt(tss.EC().Params().N))
+	}
+	_, e := CheckIndexes(tss.EC(), indexes)
+	assert.NoError(t, e)
+
+	indexes = append(indexes, tss.EC().Params().N)
+	_, e = CheckIndexes(tss.EC(), indexes)
+	assert.Error(t, e)
+}
+
 func TestCreate(t *testing.T) {
 	num, threshold := 5, 3
 
@@ -27,7 +53,7 @@ func TestCreate(t *testing.T) {
 		ids = append(ids, common.GetRandomPositiveInt(tss.EC().Params().N))
 	}
 
-	vs, _, err := Create(threshold, secret, ids)
+	vs, _, err := Create(tss.EC(), threshold, secret, ids)
 	assert.Nil(t, err)
 
 	assert.Equal(t, threshold+1, len(vs))
@@ -55,7 +81,7 @@ func TestVerify(t *testing.T) {
 		ids = append(ids, common.GetRandomPositiveInt(tss.EC().Params().N))
 	}
 
-	vs, shares, err := Create(threshold, secret, ids)
+	vs, shares, err := Create(tss.EC(), threshold, secret, ids)
 	assert.NoError(t, err)
 
 	for i := 0; i < num; i++ {
@@ -73,7 +99,7 @@ func TestReconstruct(t *testing.T) {
 		ids = append(ids, common.GetRandomPositiveInt(tss.EC().Params().N))
 	}
 
-	_, shares, err := Create(threshold, secret, ids)
+	_, shares, err := Create(tss.EC(), threshold, secret, ids)
 	assert.NoError(t, err)
 
 	secret2, err2 := shares[:threshold-1].ReConstruct()

--- a/ecdsa/keygen/round_1.go
+++ b/ecdsa/keygen/round_1.go
@@ -52,7 +52,7 @@ func (round *round1) Start() *tss.Error {
 
 	// 2. compute the vss shares
 	ids := round.Parties().IDs().Keys()
-	vs, shares, err := vss.Create(round.Threshold(), ui, ids)
+	vs, shares, err := vss.Create(tss.EC(), round.Threshold(), ui, ids)
 	if err != nil {
 		return round.WrapError(err, Pi)
 	}

--- a/ecdsa/resharing/round_1_old_step_1.go
+++ b/ecdsa/resharing/round_1_old_step_1.go
@@ -53,7 +53,7 @@ func (round *round1) Start() *tss.Error {
 	}
 
 	// 2.
-	vi, shares, err := vss.Create(round.NewThreshold(), wi, newKs)
+	vi, shares, err := vss.Create(tss.EC(), round.NewThreshold(), wi, newKs)
 	if err != nil {
 		return round.WrapError(err, round.PartyID())
 	}

--- a/ecdsa/signing/prepare.go
+++ b/ecdsa/signing/prepare.go
@@ -47,7 +47,7 @@ func PrepareForSigning(i, pax int, xi *big.Int, ks []*big.Int, bigXs []*crypto.E
 			if j == c {
 				continue
 			}
-			ksc, ksj := ks[c], ks[j]
+			ksc, ksj := modQ.Add(ks[c], zero), modQ.Add(ks[j], zero)
 			if ksj.Cmp(ksc) == 0 {
 				err = fmt.Errorf("the indices of two parties are equal")
 				return

--- a/eddsa/keygen/round_1.go
+++ b/eddsa/keygen/round_1.go
@@ -44,7 +44,7 @@ func (round *round1) Start() *tss.Error {
 
 	// 2. compute the vss shares
 	ids := round.Parties().IDs().Keys()
-	vs, shares, err := vss.Create(round.Threshold(), ui, ids)
+	vs, shares, err := vss.Create(tss.EC(), round.Threshold(), ui, ids)
 	if err != nil {
 		return round.WrapError(err, Pi)
 	}

--- a/eddsa/resharing/round_1_old_step_1.go
+++ b/eddsa/resharing/round_1_old_step_1.go
@@ -50,7 +50,7 @@ func (round *round1) Start() *tss.Error {
 	wi := signing.PrepareForSigning(i, len(round.OldParties().IDs()), xi, ks)
 
 	// 2.
-	vi, shares, err := vss.Create(round.NewThreshold(), wi, newKs)
+	vi, shares, err := vss.Create(tss.EC(), round.NewThreshold(), wi, newKs)
 	if err != nil {
 		return round.WrapError(err, round.PartyID())
 	}


### PR DESCRIPTION
Hotfix with two vulnerabilities identified. The first change makes the comparison of Feldman VSS values modulo the curve order. That avoids a malicious user from sending the order of the elliptic curve as their id, which would evaluate to zero, revealing the other player's secret. The second change makes the comparison of user IDs modulo the curve order. That avoids a potential crash during the calculation of modular inverses.