### PR TITLE
Minor change: ECDSA: changing a warn to a panic statement.

### DIFF
--- a/ecdsa/keygen/save_data.go
+++ b/ecdsa/keygen/save_data.go
@@ -8,9 +8,9 @@ package keygen
 
 import (
 	"encoding/hex"
+	"errors"
 	"math/big"
 
-	"github.com/binance-chain/tss-lib/common"
 	"github.com/binance-chain/tss-lib/crypto"
 	"github.com/binance-chain/tss-lib/crypto/paillier"
 	"github.com/binance-chain/tss-lib/tss"
@@ -68,7 +68,7 @@ func (preParams LocalPreParams) Validate() bool {
 
 func (preParams LocalPreParams) ValidateWithProof() bool {
 	return preParams.Validate() &&
-		//preParams.Alpha != nil &&
+		// preParams.Alpha != nil &&
 		preParams.Beta != nil &&
 		preParams.P != nil &&
 		preParams.Q != nil
@@ -87,7 +87,7 @@ func BuildLocalSaveDataSubset(sourceData LocalPartySaveData, sortedIDs tss.Sorte
 	for j, id := range sortedIDs {
 		savedIdx, ok := keysToIndices[hex.EncodeToString(id.Key)]
 		if !ok {
-			common.Logger.Warning("BuildLocalSaveDataSubset: unable to find a signer party in the local save data", id)
+			panic(errors.New("BuildLocalSaveDataSubset: unable to find a signer party in the local save data"))
 		}
 		newData.Ks[j] = sourceData.Ks[savedIdx]
 		newData.NTildej[j] = sourceData.NTildej[savedIdx]


### PR DESCRIPTION
Minor change: ECDSA: changing a warn to a panic statement. This change could have been made along c58e4b5ad1b4243c1ce7a8dee9544744073c48fd ( commit with message "Additional check when Ks mismatch in savedata and sortedID" ). 